### PR TITLE
Fix need absolute firewall path for CentOS 7

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -281,7 +281,7 @@ verify_firewall_cmd() {
     # Check if exists
     if command -v "$_cmd" > /dev/null 2>&1; then
       # Found
-      FIREWALL=$_cmd
+      FIREWALL=$(command -v "$_cmd" 2>/dev/null)
       return
     fi
   done
@@ -565,19 +565,19 @@ systemd_disable() {
 
 # Compose firewall rule
 firewall_rule() {
-  case $FIREWALL in
+  case $(basename "$FIREWALL") in
     firewall-cmd)
       printf "%s\n%s\n" \
-        "firewall-cmd --add-port=$NODE_EXPORTER_PORT/tcp --permanent" \
-        "firewall-cmd --reload"
+        "$FIREWALL --add-port=$NODE_EXPORTER_PORT/tcp --permanent" \
+        "$FIREWALL --reload"
       ;;
     ufw)
       printf "%s\n" \
-        "ufw allow $NODE_EXPORTER_PORT/tcp"
+        "$FIREWALL allow $NODE_EXPORTER_PORT/tcp"
       ;;
     iptables)
       printf "%s\n" \
-        "iptables -A INPUT -p tcp --dport $NODE_EXPORTER_PORT -m state --state NEW -j ACCEPT"
+        "$FIREWALL -A INPUT -p tcp --dport $NODE_EXPORTER_PORT -m state --state NEW -j ACCEPT"
       ;;
     *) fatal "Unknown firewall '$FIREWALL'" ;;
   esac

--- a/install.sh
+++ b/install.sh
@@ -281,7 +281,7 @@ verify_firewall_cmd() {
     # Check if exists
     if command -v "$_cmd" > /dev/null 2>&1; then
       # Found
-      FIREWALL=$(command -v "$_cmd" 2>/dev/null)
+      FIREWALL=$_cmd
       return
     fi
   done
@@ -565,19 +565,21 @@ systemd_disable() {
 
 # Compose firewall rule
 firewall_rule() {
-  case $(basename "$FIREWALL") in
+  _firewall_path=$(command -v "$FIREWALL" 2>&1 || :)
+
+  case $FIREWALL in
     firewall-cmd)
       printf "%s\n%s\n" \
-        "$FIREWALL --add-port=$NODE_EXPORTER_PORT/tcp --permanent" \
-        "$FIREWALL --reload"
+        "$_firewall_path --add-port=$NODE_EXPORTER_PORT/tcp --permanent" \
+        "$_firewall_path --reload"
       ;;
     ufw)
       printf "%s\n" \
-        "$FIREWALL allow $NODE_EXPORTER_PORT/tcp"
+        "$_firewall_path allow $NODE_EXPORTER_PORT/tcp"
       ;;
     iptables)
       printf "%s\n" \
-        "$FIREWALL -A INPUT -p tcp --dport $NODE_EXPORTER_PORT -m state --state NEW -j ACCEPT"
+        "$_firewall_path -A INPUT -p tcp --dport $NODE_EXPORTER_PORT -m state --state NEW -j ACCEPT"
       ;;
     *) fatal "Unknown firewall '$FIREWALL'" ;;
   esac


### PR DESCRIPTION
Been playing around a bit with your script lately.
Noticed this error on CentOS 7 where `firewall-cmd` full path seems mandatory:

Steps to reproduce:

1. Install CentOS Linux release 7.9.2009 (Core)
2. Execute current `install.sh` script
3. Run `journalctl -u node_exporter` to check why `node_exporter.service` fails

```
Jan 02 12:57:27 some.system.tld systemd[1]: [/etc/systemd/system/node_exporter.service:23] Executable path is not absolute, ignoring: firewall-cmd --add-port=9100/tcp --permanent
Jan 02 12:57:27 some.system.tld systemd[1]: [/etc/systemd/system/node_exporter.service:24] Executable path is not absolute, ignoring: firewall-cmd --reload
```

This patch replaces firewall binary with full path to firewall binary.