### PR TITLE
Fix trailing slashes when not needed

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -90,16 +90,19 @@ quote() {
 # Add indentation and trailing slash to quoted args except last one
 # Also don't add trailing slash to command if no args are given
 quote_indent() {
+   _arg_count=1
+
   if [ $# -ge 1 ]; then
     printf ' \\\n'
   fi
-  _arg_count=1
+ 
   for _arg in "$@"; do
     if [ $_arg_count -eq $# ]; then
       printf '\t%s' "$(quote "$_arg")"
     else
       printf '\t%s \\\n' "$(quote "$_arg")"
     fi
+    _arg_count=$((_arg_count))
   done
 }
 

--- a/install.sh
+++ b/install.sh
@@ -87,11 +87,19 @@ quote() {
   done
 }
 
-# Add indentation and trailing slash to quoted args
+# Add indentation and trailing slash to quoted args except last one
+# Also don't add trailing slash to command if no args are given
 quote_indent() {
-  printf ' \\\n'
+  if [ $# -ge 1 ]; then
+    printf ' \\\n'
+  fi
+  _arg_count=1
   for _arg in "$@"; do
-    printf '\t%s \\\n' "$(quote "$_arg")"
+    if [ $_arg_count -eq $# ]; then
+      printf '\t%s' "$(quote "$_arg")"
+    else
+      printf '\t%s \\\n' "$(quote "$_arg")"
+    fi
   done
 }
 
@@ -664,8 +672,7 @@ TasksMax=infinity
 TimeoutStartSec=0
 Restart=always
 RestartSec=5s
-ExecStart=$BIN_DIR/node_exporter \\
-    $CMD_NODE_EXPORTER_EXEC
+ExecStart=$BIN_DIR/node_exporter $CMD_NODE_EXPORTER_EXEC
 EOF
 
   if ! can_skip_firewall; then
@@ -674,7 +681,7 @@ EOF
     # Prepend 'ExecStartPre=-' to each rule
     while read -r _rule; do
       _firewall="$_firewall
-    ExecStartPre=-$_rule"
+ExecStartPre=-$_rule"
     done << EOF
 $(firewall_rule)
 EOF

--- a/install.sh
+++ b/install.sh
@@ -102,7 +102,7 @@ quote_indent() {
     else
       printf '\t%s \\\n' "$(quote "$_arg")"
     fi
-    _arg_count=$((_arg_count))
+    _arg_count=$((_arg_count + 1))
   done
 }
 


### PR DESCRIPTION
On Debian 10.12, I could not get the `node_exporter` service to run.

Steps to reproduce:

1. Setup Debian 10.12 
2. Run `install.sh` script
3. Check `journalctl -ur node_exporter`

Output:
```
janv. 02 13:08:15 dmail node_exporter[4959]: node_exporter: error: unexpected ExecStartPre=-/usr/sbin/ufw, try --help
janv. 02 13:08:15 dmail systemd[1]: node_exporter.service: Main process exited, code=exited, status=1/FAILURE
janv. 02 13:08:15 dmail systemd[1]: node_exporter.service: Failed with result 'exit-code'.
janv. 02 13:08:20 dmail systemd[1]: node_exporter.service: Service RestartSec=5s expired, scheduling restart.
janv. 02 13:08:20 dmail systemd[1]: node_exporter.service: Scheduled restart job, restart counter is at 6.
janv. 02 13:08:20 dmail systemd[1]: Stopped Node exporter.
janv. 02 13:08:20 dmail systemd[1]: Started Node exporter.
janv. 02 13:08:20 dmail node_exporter[4964]: node_exporter: error: unexpected ExecStartPre=-/usr/sbin/ufw, try --help
janv. 02 13:08:20 dmail systemd[1]: node_exporter.service: Main process exited, code=exited, status=1/FAILURE
janv. 02 13:08:20 dmail systemd[1]: node_exporter.service: Failed with result 'exit-code'.
janv. 02 13:08:26 dmail systemd[1]: node_exporter.service: Service RestartSec=5s expired, scheduling restart.
janv. 02 13:08:26 dmail systemd[1]: node_exporter.service: Scheduled restart job, restart counter is at 7.
janv. 02 13:08:26 dmail systemd[1]: Stopped Node exporter.
janv. 02 13:08:26 dmail systemd[1]: Started Node exporter.
janv. 02 13:08:26 dmail node_exporter[4969]: node_exporter: error: unexpected ExecStartPre=-/usr/sbin/ufw, try --help
janv. 02 13:08:26 dmail systemd[1]: node_exporter.service: Main process exited, code=exited, status=1/FAILURE
janv. 02 13:08:26 dmail systemd[1]: node_exporter.service: Failed with result 'exit-code'.
```

This fixes unwanted trailing slashes when no arguments are passed to `node_exporter` binary.
Also fixes unwanted tab before `ExecStartPre` lines.
