### PR TITLE
Make sure we log a fatal error for non zero exit code

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -370,6 +370,10 @@ setup_tmp() {
     set +o errexit
     trap - EXIT
     rm -rf "$TMP_DIR"
+    if [ $_exit_code -ne 0 ]; then
+       fatal "Install script exited with code ${_exit_code}. Please check if node_exporter is running."
+    fi
+
     exit $_exit_code
   }
   trap cleanup INT EXIT
@@ -709,6 +713,10 @@ systemd_enable() {
 systemd_start() {
   info "systemd: Starting node_exporter"
   $SUDO systemctl restart node_exporter
+  # Wait an arbitrary amount of time for service to load (systemctl status would report successful start while starting)
+  sleep 1
+  $SUDO systemctl status node_exporter > /dev/null 2>&1
+
 }
 
 # Enable openrc service
@@ -720,6 +728,8 @@ openrc_enable() {
 openrc_start() {
   info "openrc: Starting node_exporter"
   $SUDO "$FILE_NODE_EXPORTER_SERVICE" restart
+  sleep 1
+  $SUDO "$FILE_NODE_EXPORTER_SERVICE" status > /dev/null 2>&1
 }
 
 # relabel to executable if SElinux is installed

--- a/install.sh
+++ b/install.sh
@@ -715,9 +715,9 @@ systemd_enable() {
 systemd_start() {
   info "systemd: Starting node_exporter"
   $SUDO systemctl restart node_exporter
-  # Wait an arbitrary amount of time for service to load (systemctl status would report successful start while starting)
+  # Wait an arbitrary amount of time for service to load
   sleep 1
-  $SUDO systemctl status node_exporter > /dev/null 2>&1
+  systemctl is-active --quiet node_exporter || fatal "systemd: Error starting node_exporter"
 
 }
 
@@ -730,8 +730,9 @@ openrc_enable() {
 openrc_start() {
   info "openrc: Starting node_exporter"
   $SUDO "$FILE_NODE_EXPORTER_SERVICE" restart
+  # Wait an arbitrary amount of time for service to load
   sleep 1
-  $SUDO "$FILE_NODE_EXPORTER_SERVICE" status > /dev/null 2>&1
+  rc-service --quiet node_exporter status || fatal "openrc: Error starting node_exporter"
 }
 
 # relabel to executable if SElinux is installed

--- a/install.sh
+++ b/install.sh
@@ -372,13 +372,10 @@ setup_tmp() {
 
   cleanup() {
     _exit_code=$?
+    [ "$_exit_code" -eq 0 ] || error "Install script exited with code $_exit_code"
     set +o errexit
     trap - EXIT
     rm -rf "$TMP_DIR"
-    if [ $_exit_code -ne 0 ]; then
-       fatal "Install script exited with code ${_exit_code}. Please check if node_exporter is running."
-    fi
-
     exit $_exit_code
   }
   trap cleanup INT EXIT


### PR DESCRIPTION
On both previous PR #38 and #37, `install.sh` didn't complain about any problems. I actually discovered those while checking why my machines didn't show up in prometheus.

Since you already own a `cleanup()` trapped function, I added an error message if last command exit code wasn't zero, and added a check whether `node_exporter` service is running.

Disclaimer: I did check on systemd but not on openrc. I don't own any systems that have openrc.